### PR TITLE
Feature/normalization added

### DIFF
--- a/src/cwts/networkanalysis/Network.java
+++ b/src/cwts/networkanalysis/Network.java
@@ -1389,6 +1389,10 @@ public class Network implements Serializable
             checkIntegrity();
     }
 
+    public void setNodeWeightsToTotalEdgeWeights(){
+        this.nodeWeights = this.getTotalEdgeWeightPerNodeHelper();
+    }
+
     private double[] getTotalEdgeWeightPerNodeHelper()
     {
         double[] totalEdgeWeightPerNode;

--- a/src/cwts/networkanalysis/run/RunNetworkClustering.java
+++ b/src/cwts/networkanalysis/run/RunNetworkClustering.java
@@ -62,9 +62,22 @@ public final class RunNetworkClustering
      */
     public static final double DEFAULT_RANDOMNESS = LeidenAlgorithm.DEFAULT_RANDOMNESS;
 
+    /**
+     * No normalization method.
+     */
     public static final String NONE_NORMALIZATION_METHOD = "None";
+    /**
+     * Association strenght normalization method.
+     */
     public static final String ASS_NORMALIZATION_METHOD = "AssociationStrength";
+    /**
+     * Fractionalization normalization method.
+     */
     public static final String FRAC_NORMALIZATION_METHOD = "Fractionalization";
+    /**
+     * LinLog/modularity normalization method.
+     * Work with modularity quality function.
+     */
     public static final String LINLOG_NORMALIZATION_METHOD = "LinLog/modularity";
 
     /**


### PR DESCRIPTION
Normalization methods support. The network is normalized before clustering. Please, get attention of LinLog/modularity normalization method. The goal was to reproduce the select list in VOS viewer. It can cause confusion with modularity quality function parameter.

-n --normalization <None|AssociationStrength|Fractionalization|LinLog/modularity> (default: None)
Indicates that the edge list will be normalized with the selected normalization method.
