### PR TITLE
Made createSubnetwork protected, so that it can be used internally

### DIFF
--- a/src/main/java/nl/cwts/networkanalysis/Network.java
+++ b/src/main/java/nl/cwts/networkanalysis/Network.java
@@ -1417,7 +1417,7 @@ public class Network implements Serializable
         return randomNumbers[i * nNodes + j];
     }
 
-    private Network createSubnetwork(Clustering clustering, int cluster, int[] nodes, int[] subnetworkNodes, int[] subnetworkNeighbors, double[] subnetworkEdgeWeights)
+    protected Network createSubnetwork(Clustering clustering, int cluster, int[] nodes, int[] subnetworkNodes, int[] subnetworkNeighbors, double[] subnetworkEdgeWeights)
     {
         int i, j, k;
         Network subnetwork;


### PR DESCRIPTION
This PR makes one method of `createSubnetwork` directly usable internally by declaring it `protected` instead of `private`.