### PR TITLE
Arrays: added repeat function.

### DIFF
--- a/src/main/java/nl/cwts/util/Arrays.java
+++ b/src/main/java/nl/cwts/util/Arrays.java
@@ -171,11 +171,23 @@ public final class Arrays
      */
     public static double[] createDoubleArrayOfOnes(int nElements)
     {
-        double[] values;
+        return(repeat(1.0, nElements));
+    }
 
-        values = new double[nElements];
-        java.util.Arrays.fill(values, 1);
-        return values;
+    public static int[] repeat(int value, int nElements)
+    {
+        int[] elements;
+        elements = new int[nElements];
+        java.util.Arrays.fill(elements, value);
+        return elements;
+    }
+
+    public static double[] repeat(double value, int nElements)
+    {
+        double[] elements;
+        elements = new double[nElements];
+        java.util.Arrays.fill(elements, value);
+        return elements;
     }
 
     /**

--- a/src/main/java/nl/cwts/util/Arrays.java
+++ b/src/main/java/nl/cwts/util/Arrays.java
@@ -174,6 +174,14 @@ public final class Arrays
         return(repeat(1.0, nElements));
     }
 
+    /**
+     * Creates a double array of repeated elements.
+     *
+     * @param value Element to repeat
+     * @param nElements Number of elements
+     *
+     * @return Array of repeated elements
+     */
     public static int[] repeat(int value, int nElements)
     {
         int[] elements;
@@ -182,6 +190,14 @@ public final class Arrays
         return elements;
     }
 
+    /**
+     * Creates an integer array of repeated elements.
+     *
+     * @param value Element to repeat
+     * @param nElements Number of elements
+     *
+     * @return Array of repeated elements
+     */
     public static double[] repeat(double value, int nElements)
     {
         double[] elements;


### PR DESCRIPTION
This PR adds a `repeat` function to the `Arrays` class. This is then also immediately used by the `createDoubleArrayOfOnes` for backwards compatibility.

Since this PR does add to the API (but in a backwards compatible manner), we should then increase the MINOR version, not the PATCH version, i.e. version 1.2.0.