### PR TITLE
Clustering: added some convenience functions.

### DIFF
--- a/src/main/java/nl/cwts/networkanalysis/Clustering.java
+++ b/src/main/java/nl/cwts/networkanalysis/Clustering.java
@@ -163,7 +163,7 @@ public class Clustering implements Cloneable, Serializable
         for (int i = 0; i < nNodes; i++)
         {
             int c = clusters[i];
-            if (c >= 0 && !clusterNotEmpty[c])
+            if (!clusterNotEmpty[c])
                 clusterNotEmpty[c] = true;
         }
         return clusterNotEmpty;
@@ -180,7 +180,7 @@ public class Clustering implements Cloneable, Serializable
         for (int i = 0; i < nNodes; i++)
         {
             int c = clusters[i];
-            if (c >= 0 && !clusterNotEmpty[c])
+            if (!clusterNotEmpty[c])
             {
                 clusterNotEmpty[c] = true;
                 nNonEmptyClusters += 1;
@@ -223,8 +223,7 @@ public class Clustering implements Cloneable, Serializable
 
         nNodesPerCluster = new int[nClusters];
         for (i = 0; i < nNodes; i++)
-            if (clusters[i] >= 0)
-                nNodesPerCluster[clusters[i]]++;
+            nNodesPerCluster[clusters[i]]++;
         return nNodesPerCluster;
     }
 
@@ -247,11 +246,10 @@ public class Clustering implements Cloneable, Serializable
             nNodesPerCluster[i] = 0;
         }
         for (i = 0; i < nNodes; i++)
-            if (clusters[i] >= 0)
-            {
-                nodesPerCluster[clusters[i]][nNodesPerCluster[clusters[i]]] = i;
-                nNodesPerCluster[clusters[i]]++;
-            }
+        {
+            nodesPerCluster[clusters[i]][nNodesPerCluster[clusters[i]]] = i;
+            nNodesPerCluster[clusters[i]]++;
+        }
 
         return nodesPerCluster;
     }
@@ -333,8 +331,7 @@ public class Clustering implements Cloneable, Serializable
 
         nClusters = i;
         for (i = 0; i < nNodes; i++)
-            if (clusters[i] >= 0)
-                clusters[i] = newClusters[clusters[i]];
+            clusters[i] = newClusters[clusters[i]];
     }
 
     /**
@@ -359,8 +356,7 @@ public class Clustering implements Cloneable, Serializable
     {
         double[] clusterWeight = new double[nClusters];
         for (int i = 0; i < nNodes; i++)
-            if (clusters[i] >= 0)
-                clusterWeight[this.clusters[i]] += nodeWeights[i];
+            clusterWeight[this.clusters[i]] += nodeWeights[i];
 
         return clusterWeight;
     }
@@ -414,8 +410,7 @@ public class Clustering implements Cloneable, Serializable
 
         clusters = new Cluster[nClusters];
         for (i = 0; i < nClusters; i++)
-            if (this.clusters[i] >= 0)
-                clusters[i] = new Cluster(i, clusterWeights[i]);
+            clusters[i] = new Cluster(i, clusterWeights[i]);
 
         java.util.Arrays.sort(clusters);
 
@@ -428,8 +423,7 @@ public class Clustering implements Cloneable, Serializable
         } while ((i < nClusters) && (clusters[i].weight > 0));
         nClusters = i;
         for (i = 0; i < nNodes; i++)
-            if (this.clusters[i] >= 0)
-                this.clusters[i] = newClusters[this.clusters[i]];
+            this.clusters[i] = newClusters[this.clusters[i]];
     }
 
     /**
@@ -442,8 +436,7 @@ public class Clustering implements Cloneable, Serializable
         int i;
 
         for (i = 0; i < nNodes; i++)
-            if (clusters[i] >= 0)
-                clusters[i] = clustering.clusters[clusters[i]];
+            clusters[i] = clustering.clusters[clusters[i]];
 
         nClusters = clustering.nClusters;
     }

--- a/src/main/java/nl/cwts/networkanalysis/Clustering.java
+++ b/src/main/java/nl/cwts/networkanalysis/Clustering.java
@@ -59,11 +59,8 @@ public class Clustering implements Cloneable, Serializable
         ObjectInputStream objectInputStream;
 
         objectInputStream = new ObjectInputStream(new FileInputStream(filename));
-
         clustering = (Clustering)objectInputStream.readObject();
-
         objectInputStream.close();
-
         return clustering;
     }
 
@@ -125,9 +122,7 @@ public class Clustering implements Cloneable, Serializable
         ObjectOutputStream objectOutputStream;
 
         objectOutputStream = new ObjectOutputStream(new FileOutputStream(filename));
-
         objectOutputStream.writeObject(this);
-
         objectOutputStream.close();
     }
 
@@ -159,10 +154,12 @@ public class Clustering implements Cloneable, Serializable
     public boolean[] getClusterIsNotEmpty()
     {
         boolean[] clusterIsNotEmpty;
+        int c, i;
+
         clusterIsNotEmpty = new boolean[nClusters];
-        for (int i = 0; i < nNodes; i++)
+        for (i = 0; i < nNodes; i++)
         {
-            int c = clusters[i];
+            c = clusters[i];
             if (!clusterIsNotEmpty[c])
                 clusterIsNotEmpty[c] = true;
         }
@@ -176,11 +173,13 @@ public class Clustering implements Cloneable, Serializable
     public int getNNonEmptyClusters()
     {
         boolean[] clusterIsNotEmpty;
+        int c, i, nNonEmptyClusters;
+
         clusterIsNotEmpty = new boolean[nClusters];
-        int nNonEmptyClusters = 0;
-        for (int i = 0; i < nNodes; i++)
+        nNonEmptyClusters = 0;
+        for (i = 0; i < nNodes; i++)
         {
-            int c = clusters[i];
+            c = clusters[i];
             if (!clusterIsNotEmpty[c])
             {
                 clusterIsNotEmpty[c] = true;
@@ -354,8 +353,10 @@ public class Clustering implements Cloneable, Serializable
     public double[] getClusterWeights(double[] nodeWeights)
     {
         double[] clusterWeight;
+        int i;
+
         clusterWeight = new double[nClusters];
-        for (int i = 0; i < nNodes; i++)
+        for (i = 0; i < nNodes; i++)
             clusterWeight[this.clusters[i]] += nodeWeights[i];
 
         return clusterWeight;
@@ -387,7 +388,6 @@ public class Clustering implements Cloneable, Serializable
     {
         class Cluster implements Comparable<Cluster>
         {
-
             int cluster;
             double weight;
 

--- a/src/main/java/nl/cwts/networkanalysis/Clustering.java
+++ b/src/main/java/nl/cwts/networkanalysis/Clustering.java
@@ -15,8 +15,7 @@ import java.util.Map;
  * Clustering of the nodes in a network.
  *
  * <p>
- * Each node belongs to at most one cluster. Negative clusters are used to
- * indicate that a node is not assigned to any cluster.
+ * Each node belongs to exactly one cluster.
  * </p>
  *
  * @author Ludo Waltman
@@ -159,14 +158,14 @@ public class Clustering implements Cloneable, Serializable
      */
     public boolean[] getClusterIsNotEmpty()
     {
-        boolean[] clusterNotEmpty = new boolean[nClusters];
+        boolean[] clusterIsNotEmpty = new boolean[nClusters];
         for (int i = 0; i < nNodes; i++)
         {
             int c = clusters[i];
-            if (!clusterNotEmpty[c])
-                clusterNotEmpty[c] = true;
+            if (!clusterIsNotEmpty[c])
+                clusterIsNotEmpty[c] = true;
         }
-        return clusterNotEmpty;
+        return clusterIsNotEmpty;
     }
 
     /**
@@ -175,14 +174,14 @@ public class Clustering implements Cloneable, Serializable
      */
     public int getNNonEmptyClusters()
     {
-        boolean[] clusterNotEmpty = new boolean[nClusters];
+        boolean[] clusterIsNotEmpty = new boolean[nClusters];
         int nNonEmptyClusters = 0;
         for (int i = 0; i < nNodes; i++)
         {
             int c = clusters[i];
-            if (!clusterNotEmpty[c])
+            if (!clusterIsNotEmpty[c])
             {
-                clusterNotEmpty[c] = true;
+                clusterIsNotEmpty[c] = true;
                 nNonEmptyClusters += 1;
             }
         }
@@ -250,7 +249,6 @@ public class Clustering implements Cloneable, Serializable
             nodesPerCluster[clusters[i]][nNodesPerCluster[clusters[i]]] = i;
             nNodesPerCluster[clusters[i]]++;
         }
-
         return nodesPerCluster;
     }
 
@@ -309,11 +307,11 @@ public class Clustering implements Cloneable, Serializable
      */
     public void removeEmptyClustersLargerThan(int minimumCluster)
     {
-        boolean[] clusterNotEmpty;
+        boolean[] clusterIsNotEmpty;
         int i, j;
         int[] newClusters;
 
-        clusterNotEmpty = getClusterIsNotEmpty();
+        clusterIsNotEmpty = getClusterIsNotEmpty();
 
         // Do not relabel until minimumCluster
         newClusters = new int[nClusters];
@@ -323,12 +321,11 @@ public class Clustering implements Cloneable, Serializable
         // Relabel starting from minimumCluster
         i = j;
         for ( ; j < nClusters; j++)
-            if (clusterNotEmpty[j])
+            if (clusterIsNotEmpty[j])
             {
                 newClusters[j] = i;
                 i++;
             }
-
         nClusters = i;
         for (i = 0; i < nNodes; i++)
             clusters[i] = newClusters[clusters[i]];
@@ -354,7 +351,8 @@ public class Clustering implements Cloneable, Serializable
      */
     public double[] getClusterWeights(double[] nodeWeights)
     {
-        double[] clusterWeight = new double[nClusters];
+        double[] clusterWeight;
+        clusterWeight = new double[nClusters];
         for (int i = 0; i < nNodes; i++)
             clusterWeight[this.clusters[i]] += nodeWeights[i];
 
@@ -404,9 +402,11 @@ public class Clustering implements Cloneable, Serializable
         }
 
         Cluster[] clusters;
-        double[] clusterWeights = getClusterWeights(nodeWeights);
+        double[] clusterWeights;
         int i;
         int[] newClusters;
+
+    	clusterWeights = getClusterWeights(nodeWeights);
 
         clusters = new Cluster[nClusters];
         for (i = 0; i < nClusters; i++)
@@ -437,7 +437,6 @@ public class Clustering implements Cloneable, Serializable
 
         for (i = 0; i < nNodes; i++)
             clusters[i] = clustering.clusters[clusters[i]];
-
         nClusters = clustering.nClusters;
     }
 

--- a/src/main/java/nl/cwts/networkanalysis/Clustering.java
+++ b/src/main/java/nl/cwts/networkanalysis/Clustering.java
@@ -158,7 +158,8 @@ public class Clustering implements Cloneable, Serializable
      */
     public boolean[] getClusterIsNotEmpty()
     {
-        boolean[] clusterIsNotEmpty = new boolean[nClusters];
+        boolean[] clusterIsNotEmpty;
+        clusterIsNotEmpty = new boolean[nClusters];
         for (int i = 0; i < nNodes; i++)
         {
             int c = clusters[i];
@@ -174,7 +175,8 @@ public class Clustering implements Cloneable, Serializable
      */
     public int getNNonEmptyClusters()
     {
-        boolean[] clusterIsNotEmpty = new boolean[nClusters];
+        boolean[] clusterIsNotEmpty;
+        clusterIsNotEmpty = new boolean[nClusters];
         int nNonEmptyClusters = 0;
         for (int i = 0; i < nNodes; i++)
         {


### PR DESCRIPTION
This PR allows to also indicate negative cluster identifiers for nodes, which could then be interpreted as indicating that a node is not assigned to a cluster. In principle, a negative cluster could already be set, but this would break a number of operations that assume that cluster numbers are non-negative.

Additionally, three convenience functions are added: `clusterWeights` and `getClusterIsNotEmpty` and `getNNonEmptyClusters`, which are also used internally for some operations.

Finally, the relabeling of empty clusters can now also be done starting from some higher cluster number in `removeEmptyClustersLargerThan`.